### PR TITLE
Add content on collapsible sections that are open by default

### DIFF
--- a/content/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections.md
@@ -43,6 +43,25 @@ After a reader clicks {% octicon "triangle-right" aria-label="The right triangle
 
 ![Screenshot of the Markdown above on this page as rendered on {% data variables.product.prodname_dotcom %}, indicating that a collapsed section can contain headers, sentences of text, images, and code blocks.](/assets/images/help/writing/open-collapsed-section.png)
 
+## Creating a collapsible section that is open by default
+````markdown
+<details open>
+
+<summary>Tips for collapsible sections that are open by default</summary>
+
+### You can add a header
+
+You can add text within a collapsed section. 
+
+You can add an image or a code block, too.
+
+```python
+   print("Hello World")
+```
+
+</details>
+````
+
 ## Further reading
 
 * [{% data variables.product.prodname_dotcom %} Flavored Markdown Spec](https://github.github.com/gfm/)


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #34836

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->
Also I searched and there were no existing issues or PRs.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Added content that provides an example of how to create a collapsible section that is open by default.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
